### PR TITLE
Update `AEPTestUtils` to v5.0.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -26,13 +26,13 @@ end
 
 target 'UnitTests' do
   core_pods
-  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-testutils-ios.git', :branch => 'path-options-refactor2'
+  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-testutils-ios.git', :tag => 'v5.0.0'
 end
 
 target 'FunctionalTests' do
   core_pods
   edge_pods
-  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-testutils-ios.git', :branch => 'path-options-refactor2'
+  pod 'AEPTestUtils', :git => 'https://github.com/adobe/aepsdk-testutils-ios.git', :tag => 'v5.0.0'
 end
 
 target 'TestAppSwiftUI' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -14,9 +14,9 @@ PODS:
     - AEPCore (< 6.0.0, >= 5.0.0)
   - AEPRulesEngine (5.0.0)
   - AEPServices (5.0.0)
-  - AEPTestUtils (1.0.0-beta):
-    - AEPCore (>= 4.0.0)
-    - AEPServices (>= 4.0.0)
+  - AEPTestUtils (5.0.0):
+    - AEPCore
+    - AEPServices
   - SwiftLint (0.52.0)
 
 DEPENDENCIES:
@@ -27,7 +27,7 @@ DEPENDENCIES:
   - AEPLifecycle (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `staging`)
   - AEPRulesEngine (from `https://github.com/adobe/aepsdk-rulesengine-ios.git`, branch `staging`)
   - AEPServices (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `staging`)
-  - AEPTestUtils (from `https://github.com/adobe/aepsdk-testutils-ios.git`, branch `path-options-refactor2`)
+  - AEPTestUtils (from `https://github.com/adobe/aepsdk-testutils-ios.git`, tag `v5.0.0`)
   - SwiftLint (= 0.52.0)
 
 SPEC REPOS:
@@ -55,31 +55,31 @@ EXTERNAL SOURCES:
     :branch: staging
     :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPTestUtils:
-    :branch: path-options-refactor2
     :git: https://github.com/adobe/aepsdk-testutils-ios.git
+    :tag: v5.0.0
 
 CHECKOUT OPTIONS:
   AEPCore:
-    :commit: f44b7b0d66e2c6a1454b51ed5a9d835bfbc2a8f9
+    :commit: 2c65647d337dd94a75e119618fc3660e57e25bd0
     :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPEdge:
-    :commit: 5c9a1543ea1f37e249bcfce47c1d0087db86897b
+    :commit: 52ede9be9a84f9d4a2b226be4e68d33035ea18c9
     :git: https://github.com/adobe/aepsdk-edge-ios.git
   AEPEdgeIdentity:
-    :commit: c7b0885c4369baa8d12b7837c08f0a41bc654c39
+    :commit: f5465e419e1e4a314a53e040b68d9af8fd473393
     :git: https://github.com/adobe/aepsdk-edgeidentity-ios.git
   AEPLifecycle:
-    :commit: f44b7b0d66e2c6a1454b51ed5a9d835bfbc2a8f9
+    :commit: 2c65647d337dd94a75e119618fc3660e57e25bd0
     :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPRulesEngine:
-    :commit: 7750ad5041c23c76053713441546116738e0fdcb
+    :commit: 814672b136b6c71ab529a3f1366f3bf16cd9a532
     :git: https://github.com/adobe/aepsdk-rulesengine-ios.git
   AEPServices:
-    :commit: f44b7b0d66e2c6a1454b51ed5a9d835bfbc2a8f9
+    :commit: 2c65647d337dd94a75e119618fc3660e57e25bd0
     :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPTestUtils:
-    :commit: 8212672430dad334ad72544a2d57f41764db7dec
     :git: https://github.com/adobe/aepsdk-testutils-ios.git
+    :tag: v5.0.0
 
 SPEC CHECKSUMS:
   AEPAssurance: 765587ef65481bab544aa25efcfa294e14161d49
@@ -89,9 +89,9 @@ SPEC CHECKSUMS:
   AEPLifecycle: d4e0e1e86d6225d87203875d67f56c48f7ab7f67
   AEPRulesEngine: fe5800653a4bee07b1e41e61b4d5551f0dba557b
   AEPServices: e42e5118128e81c0f797fdfb1dc9c4a714d644b8
-  AEPTestUtils: 756e5997318be74584057d7628941c737d358640
+  AEPTestUtils: 20495b368da57904ca2e9f241d1d8b114f9887b5
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
-PODFILE CHECKSUM: 5be234e214b24550c26fa2c2e7f45db88678cba2
+PODFILE CHECKSUM: 34c044c2dd62df95be89d4dab391503ee84ae364
 
 COCOAPODS: 1.14.3

--- a/Tests/FunctionalTests/EdgeBridgeFunctionalTests.swift
+++ b/Tests/FunctionalTests/EdgeBridgeFunctionalTests.swift
@@ -34,8 +34,7 @@ class EdgeBridgeFunctionalTests: TestBase, AnyCodableAsserts {
         super.setUp()
         ServiceProvider.shared.networkService = mockNetworkService
         continueAfterFailure = false
-        FileManager.default.clearCache()
-        FileManager.default.removeAdobeCacheDirectory()
+        NamedCollectionDataStore.clear()
 
         // hub shared state update for 1 extension versions Edge, Identity, Configuration, EventHub shared state updates
         setExpectationEvent(type: EventType.hub, source: EventSource.sharedState, expectedCount: 4)
@@ -106,8 +105,8 @@ class EdgeBridgeFunctionalTests: TestBase, AnyCodableAsserts {
         """
 
         assertExactMatch(
-            expected: getAnyCodable(expectedJSON)!,
-            actual: getAnyCodable(networkRequests[0]),
+            expected: expectedJSON,
+            actual: networkRequests[0],
             typeMatchPaths: ["events[0].xdm._id", "events[0].xdm.timestamp", "events[0].data.__adobe.analytics.contextData.a\\.AppID"])
     }
 
@@ -153,8 +152,8 @@ class EdgeBridgeFunctionalTests: TestBase, AnyCodableAsserts {
         """
 
         assertExactMatch(
-            expected: getAnyCodable(expectedJSON)!,
-            actual: getAnyCodable(networkRequests[0]),
+            expected: expectedJSON,
+            actual: networkRequests[0],
             typeMatchPaths: ["events[0].xdm._id", "events[0].xdm.timestamp", "events[0].data.__adobe.analytics.contextData.a\\.AppID"])
     }
 
@@ -204,8 +203,8 @@ class EdgeBridgeFunctionalTests: TestBase, AnyCodableAsserts {
         """
 
         assertExactMatch(
-            expected: getAnyCodable(expectedJSON)!,
-            actual: getAnyCodable(networkRequests[0]),
+            expected: expectedJSON,
+            actual: networkRequests[0],
             typeMatchPaths: ["events[0].xdm._id", "events[0].xdm.timestamp", "events[0].data.__adobe.analytics.contextData.a\\.AppID"])
     }
 

--- a/Tests/UnitTests/EdgeBridgeTests.swift
+++ b/Tests/UnitTests/EdgeBridgeTests.swift
@@ -97,7 +97,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     func testHandleTrackEvent_withActionFieldWithEmptyValue_dispatchesEdgeRequestEvent_withoutAction() {
@@ -139,7 +139,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     func testHandleTrackEvent_withActionFieldWithNilValue_dispatchesEdgeRequestEvent_withoutAction() {
@@ -181,7 +181,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     func testHandleTrackEvent_withStateField_dispatchesEdgeRequestEvent() {
@@ -220,7 +220,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     func testHandleTrackEvent_withStateFieldWithNilValue_dispatchesEdgeRequestEvent_withoutState() {
@@ -262,7 +262,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     func testHandleTrackEvent_withStateFieldWithEmptyValue_dispatchesEdgeRequestEvent_withoutState() {
@@ -304,7 +304,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     func testHandleTrackEvent_withContextDataFieldUsingReservedPrefix_dispatchesEdgeRequestEvent() {
@@ -345,7 +345,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     func testHandleTrackEvent_withContextDataNotUsingReservedPrefix_dispatchesEdgeRequestEvent() {
@@ -386,7 +386,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     func testHandleTrackEvent_withDataField_dispatchesEdgeRequestEvent() {
@@ -417,7 +417,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     func testHandleTrackEvent_trackAction_dispatchesEdgeRequestEvent() {
@@ -471,7 +471,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     func testHandleTrackEvent_trackState_dispatchesEdgeRequestEvent() {
@@ -522,7 +522,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     // Test event still dispatched if request contains data but no 'track' data.
@@ -555,7 +555,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     // Tests event is not dispatched if no track data is available
@@ -630,7 +630,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     func testHandleTrackEvent_withContextDataFieldUsingReservedPrefix_emptyValue_dispatchesEdgeRequestEvent_emptyValuesAllowed() {
@@ -673,7 +673,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     func testHandleTrackEvent_withContextDataFieldUsingReservedPrefix_nilValue_dispatchesEdgeRequestEvent_nilValuesIgnored() {
@@ -715,7 +715,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     // Test empty string keys are not allowed
@@ -758,7 +758,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     // Public track APIs define context data as [String: Any] which do not allow null keys.
@@ -803,7 +803,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     // Test empty string values are allowed
@@ -845,7 +845,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     func testHandleTrackEvent_withContextDataField_nilValue_dispatchesEdgeRequestEvent_nilValuesIgnored() {
@@ -887,10 +887,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        let codableExpected = getAnyCodable(expectedJSON)
-        let codableDispatched = getAnyCodable(dispatchedEvent)
-
-        assertEqual(expected: codableExpected, actual: codableDispatched)
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     func testHandleTrackEvent_withReservedPrefix_onlyRemovesPrefix_dispatchesEdgeRequestEvent() {
@@ -952,7 +949,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     func testHandleTrackEvent_withCharacterBeforeReservedCharacters_dispatchesEdgeRequestEvent() {
@@ -1009,7 +1006,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     // Test context data values are cleaned such that only String, Number, and Character types are allowed
@@ -1189,7 +1186,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON), actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
     func testHandleRulesEngineResponse_withNilEventData_doesNotDispatchEvent() {
@@ -1542,7 +1539,7 @@ class EdgeBridgeTests: XCTestCase, AnyCodableAsserts {
             }
         """
 
-        assertEqual(expected: getAnyCodable(expectedJSON)!, actual: getAnyCodable(dispatchedEvent))
+        assertEqual(expected: expectedJSON, actual: dispatchedEvent)
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates the dependency `AEPTestUtils` from: 
branch `'path-options-refactor2'` -> tag `v5.0.0`

Usage updates:
1. Persistence clearing helper call
2. `assertEqual` call

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
