### PR TITLE
Remove cast to Optional Any when cleaning and formatting contextData.

### DIFF
--- a/Sources/EdgeBridge.swift
+++ b/Sources/EdgeBridge.swift
@@ -236,18 +236,27 @@ public class EdgeBridge: NSObject, Extension {
     private func cleanContextData(_ data: [String: Any]) -> [String: Any] {
         let invalidTypeError = "Value must be String, Number, Bool or Character"
 
-        let cleanedData = data.filter {
-            switch $0.value {
-            case is NSNumber, is String, is Character:
-                return true
+        // Filter unsupported types and nils while unwrapping any Optionals
+        let cleanedData: [String: Any] = data.compactMapValues {
+            switch $0 {
+            case is String:
+                return $0 as? String
+            case is Character:
+                return $0 as? Character
+            case is NSNumber:
+                return $0 as? NSNumber
             default:
-                Log.debug(label: EdgeBridgeConstants.LOG_TAG,
-                          "cleanContextData - Dropping key '\(String(describing: $0.key))' with value '\(String(describing: $0.value))'. \(invalidTypeError)")
-                return false
+                return nil
             }
         }
 
-        return cleanedData as [String: Any]
+        let droppedKeys = Set(data.keys).subtracting(Set(cleanedData.keys))
+        if !droppedKeys.isEmpty {
+            Log.debug(label: EdgeBridgeConstants.LOG_TAG,
+                      "cleanContextData - Dropping keys '\(String(describing: droppedKeys))'. \(invalidTypeError)")
+        }
+
+        return cleanedData
     }
 
     /// Combines the application name, version, and version code into a formatted application identifier

--- a/Sources/EdgeBridge.swift
+++ b/Sources/EdgeBridge.swift
@@ -170,7 +170,7 @@ public class EdgeBridge: NSObject, Extension {
         var mutableData = data // mutable copy of data
         var analyticsData: [String: Any] = [:] // __adobe.analytics data
 
-        if let contextData = mutableData.removeValue(forKey: EdgeBridgeConstants.MobileCoreKeys.CONTEXT_DATA) as? [String: Any?], !contextData.isEmpty {
+        if let contextData = mutableData.removeValue(forKey: EdgeBridgeConstants.MobileCoreKeys.CONTEXT_DATA) as? [String: Any], !contextData.isEmpty {
             var prefixedData: [String: Any] = [:]
             var nonprefixedData: [String: Any] = [:]
 
@@ -233,7 +233,7 @@ public class EdgeBridge: NSObject, Extension {
     ///
     /// - Parameter data: context data to be cleaned
     /// - Returns: dictionary where values are only of type String, Number, or Character
-    private func cleanContextData(_ data: [String: Any?]) -> [String: Any] {
+    private func cleanContextData(_ data: [String: Any]) -> [String: Any] {
         let invalidTypeError = "Value must be String, Number, Bool or Character"
 
         let cleanedData = data.filter {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes cast to `Any?` when cleaning and formatting `contextData`.
The erroneous cast causes the contextData values to be of type `Optional` which then fails equality checks in Rules against the `data.__adobe.analytics.contextData` values.

internal Jira: MOB-24281

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
